### PR TITLE
Completeness kit fix

### DIFF
--- a/src/main/scala/rx/lang/scala/observables/BlockingObservable.scala
+++ b/src/main/scala/rx/lang/scala/observables/BlockingObservable.scala
@@ -158,9 +158,9 @@ class BlockingObservable[+T] private[scala] (val o: Observable[T])
    *            the initial value that will be yielded by the `Iterable` sequence if the [[Observable]] has not yet emitted an item
    * @return an `Iterable` that on each iteration returns the item that the [[Observable]] has most recently emitted
    */
-  def mostRecent[T](initialValue: T): Iterable[T] = {
-    val asJavaT = asJava.asInstanceOf[rx.observables.BlockingObservable[T]]
-    asJavaT.mostRecent(initialValue).asScala: Iterable[T] // useless ascription because of compiler bug
+  def mostRecent[U >: T](initialValue: U): Iterable[U] = {
+    val asJavaU = asJava.asInstanceOf[rx.observables.BlockingObservable[U]]
+    asJavaU.mostRecent(initialValue).asScala: Iterable[U] // useless ascription because of compiler bug
   }
 
   /**

--- a/src/test/scala/rx/lang/scala/completeness/BlockingObservableCompletenessKit.scala
+++ b/src/test/scala/rx/lang/scala/completeness/BlockingObservableCompletenessKit.scala
@@ -31,6 +31,7 @@ class BlockingObservableCompletenessKit extends CompletenessKit {
     "last(Func1[_ >: T, Boolean])" -> "[use `Observable.filter(p).toBlocking.last`]",
     "lastOrDefault(T)" -> "lastOrElse(=> U)",
     "lastOrDefault(T, Func1[_ >: T, Boolean])" -> "[use `Observable.filter(p).toBlocking.lastOrElse(=> U)`]",
+    "mostRecent(T)" -> "mostRecent(U)",
     "single(Func1[_ >: T, Boolean])" -> "[use `Observable.filter(p).toBlocking.single`]",
     "singleOrDefault(T)" -> "singleOrElse(=> U)",
     "singleOrDefault(T, Func1[_ >: T, Boolean])" -> "[use `Observable.filter(p).toBlocking.singleOrElse(=> U)`]",

--- a/src/test/scala/rx/lang/scala/observables/BlockingObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/observables/BlockingObservableTest.scala
@@ -18,12 +18,35 @@ package rx.lang.scala.observables
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Test, Ignore}
 import org.scalatest.junit.JUnitSuite
 import scala.language.postfixOps
 import rx.lang.scala.Observable
 
 class BlockingObservableTest extends JUnitSuite {
+
+  // Tests which needn't be run:
+
+  @Ignore
+  def testMostRecent() {
+    class Fruit {
+      def printMe(): Unit = println(this)
+    }
+    class Apple extends Fruit
+    class Pear extends Fruit
+    
+    val apples: Observable[Apple] = Observable.just(new Apple) ++ Observable.never
+    
+    // If we give a Pear as initial value for BlockingObservable[Apple].mostRecent,
+    // the Iterable returned by mostRecent contains elements of the least common
+    // supertype of Apple and Pear, which is Fruit.
+    // This works because Scala allows upper bounds for type parameters.
+    val firstFruit = apples.toBlocking.mostRecent(new Pear).head
+    
+    firstFruit.printMe()
+  }
+
+  // Tests which have to be run:
 
   @Test
   def testSingleOption() {


### PR DESCRIPTION
It turned out that what I said [here](https://github.com/ReactiveX/RxScala/pull/174#discussion_r37787494) makes no sense:
I did not mean what you did in https://github.com/zsxwing/RxScala/commit/bdae1eb0c7b3dffc241234fd6ac96e3a7f77f375 (that would be a typesafety breach, see the example in the message of the revert commit), but I wanted to rename the type parameter of `BlockingObservable.mostRecent` from `U` into `T`, without removing the upper bound. But it turns out that the upper bound, which is the type parameter of `BlockingObservable`, is named `T` as well, so we would have a name clash, so we cannot do the renaming.
Sorry for the confusion ;-)
